### PR TITLE
Update warning message

### DIFF
--- a/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/DummyManagementAuth.scala
+++ b/server/servers/deploy/src/main/scala/com/prisma/deploy/server/auth/DummyManagementAuth.scala
@@ -7,7 +7,8 @@ case class DummyManagementAuth() extends ManagementAuth {
     println(
       "Warning: Management API authentication is disabled. " +
         "To protect your management server you should provide one (not both) of the environment variables " +
-        "'CLUSTER_PUBLIC_KEY' (asymmetric, deprecated soon) or 'PRISMA_MANAGEMENT_API_JWT_SECRET' (symmetric JWT)."
+        "'CLUSTER_PUBLIC_KEY' (asymmetric, deprecated soon) or 'PRISMA_MANAGEMENT_API_JWT_SECRET' (symmetric JWT). " +
+        "Or you can add managementApiSecret to PRISMA_CONFIG (recommended, also symmetric JWT)."
     )
 
     Success(())


### PR DESCRIPTION
The warning message for Management API Security disabled tells users the old way to do things.
Instead, we should tell users the new way to do things using PRISMA_CONFIG.

The contributing guidelines say that PRs for server should be made against the alpha branch. This is technically a PR for server, but it's just updating warning text. If you're ok, it'd be nice to merge directly to master. Please let me know and I'll change the base fork to master.