### PR TITLE
Enum generation fix in Typescript codegen

### DIFF
--- a/client/src/codegen/typescript-client.ts
+++ b/client/src/codegen/typescript-client.ts
@@ -143,12 +143,12 @@ export type ${type.name}_Output = string`
       if (type.name === 'PrismaDatabase') {
         return ``
       }
-      return `${this.renderDescription(type.description!)}export type ${
+      return `${this.renderDescription(type.description!)}export enum ${
         type.name
-      } = ${type
+      } {\n ${type
         .getValues()
-        .map(e => `  '${e.name}'`)
-        .join(' |\n')}`
+        .map(e => `${e.name} = '${e.value}'`)
+        .join(',\n')}\n}`
     },
   }
 


### PR DESCRIPTION
Updated codegen to generate typescript enums (**not union types**) from graphql enums.

Before:
```
  GraphQLEnumType: (type: GraphQLEnumType): string => {
      if (type.name === 'PrismaDatabase') {
        return ``
      }
      return `${this.renderDescription(type.description!)}export type ${
        type.name
      } = ${type
        .getValues()
        .map(e => `  '${e.name}'`)
        .join(' |\n')}`
    },
```
```
export type UserRole = "ADMIN" | "USER";
```

After:
```
  GraphQLEnumType: (type: GraphQLEnumType): string => {
      if (type.name === 'PrismaDatabase') {
        return ``
      }
      return `${this.renderDescription(type.description!)}export enum ${
        type.name
      } {\n ${type
        .getValues()
        .map(e => `${e.name} = '${e.value}'`)
        .join(',\n')}\n}`
    },
```
```
export enum UserRole {
  ADMIN = "ADMIN",
  USER = "USER"
}
```

Given that the following `enum` is declared in GraphQL:
```
enum UserRole {
  ADMIN
  USER
}
```