### PR TITLE
Extended architecture compatibility (ARM and more)

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -33,7 +33,7 @@ def commonDockerImageSettings(imageName: String) = commonServerSettings ++ Seq(
     val targetDir = "/app"
 
     new Dockerfile {
-      from("anapsix/alpine-java")
+      from("openjdk:8-slim")
       copy(appDir, targetDir)
       copy(prerunHookFile , s"$targetDir/prerun_hook.sh")
       runShell(s"touch", s"$targetDir/start.sh")

--- a/server/docker-compose/postgres/dev-postgres.yml
+++ b/server/docker-compose/postgres/dev-postgres.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   postgres:
-    image: timms/postgres-logging:10.3
+    image: postgres:10
     container_name: psql
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -11,3 +11,5 @@ services:
       POSTGRES_PASSWORD: prisma
     ports:
       - "0.0.0.0:5432:5432"
+    volumes:
+      - ./initdb.d:/docker-entrypoint-initdb.d/

--- a/server/docker-compose/postgres/initdb.d/config.sh
+++ b/server/docker-compose/postgres/initdb.d/config.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+sed -ri "s/#log_statement = 'none'/log_statement = 'all'/g" /var/lib/postgresql/data/postgresql.conf


### PR DESCRIPTION
Switching the prisma base image to [`openjdk:8-slim`](https://github.com/docker-library/openjdk/blob/c3023e4da10d10e9c9775eabe2d7baac146e7ae1/8/jdk/slim/Dockerfile) maintains compatability with `anapsix/alpine-java` (glibc), instantly enables multi-arch docker images (yay ARM!), and increases future stability and security by depending on an official image.

In terms of testing, PG's image also comes with ARM support out of the box, so I've replaced `timms/postgres-logging` with the official PG image and added the old image's logging script.

PG's tests maintain current coverage on amd64 and armhf. There are no official MySQL or Mongo docker images for ARM, so I'll leave that be for now.

In terms of CI for ARM images, running [cross builds](https://www.balena.io/blog/building-arm-containers-on-any-x86-machine-even-dockerhub/) like @balena-io does has worked wonders for me, but I'll leave that to the prisma team.

In the interim, [`pckzs/prisma`](https://hub.docker.com/r/pckzs/prisma) is multi-arch compatible image on the prisma/prisma@617c80d release. I will make it an automated build if this PR doesn't get traction.

- [ ] Is there a reason prisma depended on the Oracle JDK?
- [ ] The ARM build needs further (live) testing.

Addresses #2909 and #2207.