### PR TITLE
Fix link in FAQ docs

### DIFF
--- a/docs/1.27/faq/index.mdx
+++ b/docs/1.27/faq/index.mdx
@@ -12,4 +12,4 @@ export const meta = {
 - [How to reveal the Management API secret when using the Heroku integration in Prisma Cloud?](fq03)
 - [Why does Prisma require an extra server on top of my database if it replaces an ORM?](fq02)
 - [Who is using Prisma?](fq08)
-- [How to keep the version of your Prisma server in sync with the Prisma CLI?](f07)
+- [How to keep the version of your Prisma server in sync with the Prisma CLI?](fq07)

--- a/docs/1.28/faq/index.mdx
+++ b/docs/1.28/faq/index.mdx
@@ -12,4 +12,4 @@ export const meta = {
 - [How to reveal the Management API secret when using the Heroku integration in Prisma Cloud?](fq03)
 - [Why does Prisma require an extra server on top of my database if it replaces an ORM?](fq02)
 - [Who is using Prisma?](fq08)
-- [How to keep the version of your Prisma server in sync with the Prisma CLI?](f07)
+- [How to keep the version of your Prisma server in sync with the Prisma CLI?](fq07)


### PR DESCRIPTION
If you visit the docs at https://www.prisma.io/docs/faq/, the link "How to keep the version of your Prisma server in sync with the Prisma CLI?" is broken.

I believe this should fix it, though I'm not familiar with how these docs are generated.