### PR TITLE
Fix formatting of link in seed docs

### DIFF
--- a/docs/1.28/prisma-cli-and-configuration/cli-command-reference/prisma-seed-xcv8.mdx
+++ b/docs/1.28/prisma-cli-and-configuration/cli-command-reference/prisma-seed-xcv8.mdx
@@ -46,6 +46,7 @@ seed:
 ```
 
 </Code>
+
 All sample projects in the [`prisma-examples`](https://www.github.com/prisma/prisma-examples) repository are based on this seeding mechanism.
 
 **Seed service with initial data**


### PR DESCRIPTION
Without a blank line above, the markdown link does not render correctly