### PR TITLE
Upgrade `npm-run`

### DIFF
--- a/cli/packages/prisma-cli-core/package.json
+++ b/cli/packages/prisma-cli-core/package.json
@@ -101,7 +101,7 @@
     "multimatch": "^2.1.0",
     "mysql": "^2.16.0",
     "node-forge": "^0.7.1",
-    "npm-run": "4.1.2",
+    "npm-run": "5.0.1",
     "opn": "^5.1.0",
     "prisma-client-lib": "1.23.0-test.3",
     "prisma-datamodel": "1.23.0-alpha.1",


### PR DESCRIPTION
Avoid a vulnerability in older version of `npm-run`'s `sync-exec@0.6.2`: https://nvd.nist.gov/vuln/detail/CVE-2017-16024