### PR TITLE
Fix Prisma bindings URL in FAQ page

### DIFF
--- a/docs/1.23/faq/prisma-client-vs-prisma-bindings-fq06.mdx
+++ b/docs/1.23/faq/prisma-client-vs-prisma-bindings-fq06.mdx
@@ -8,7 +8,7 @@ export const meta = {
 
 ## FAQ
 
-The [Prisma client](/prisma-client) and [Prisma bindings]((https://github.com/prisma/prisma-binding)) both provide ways to interact with the Prisma server that sits on top of your database and therefore allow you to read and write data in your database. **It is generally recommended to use the Prisma client.** Prisma bindings can be used for advanced use cases when building GraphQL servers.
+The [Prisma client](/prisma-client) and [Prisma bindings](https://github.com/prisma/prisma-binding) both provide ways to interact with the Prisma server that sits on top of your database and therefore allow you to read and write data in your database. **It is generally recommended to use the Prisma client.** Prisma bindings can be used for advanced use cases when building GraphQL servers.
 
 ## Prisma bindings
 


### PR DESCRIPTION
Fixes the Prisma bindings URL to properly link to https://github.com/prisma/prisma-binding