### PR TITLE
Use generated prisma client to React-Native app

### DIFF
--- a/cli/packages/prisma-client-lib/src/Client.ts
+++ b/cli/packages/prisma-client-lib/src/Client.ts
@@ -16,7 +16,6 @@ import { mapValues } from './utils/mapValues'
 import gql from 'graphql-tag'
 import { getTypesAndWhere } from './utils'
 const log = require('debug')('binding')
-import { sign } from 'jsonwebtoken'
 import { BatchedGraphQLClient } from 'http-link-dataloader'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 import { observableToAsyncIterable } from './utils/observableToAsyncIterable'
@@ -74,7 +73,7 @@ export class Client {
 
     this.buildMethods()
 
-    const token = secret ? sign({}, secret!) : undefined
+    const token = undefined
 
     this.$graphql = this.buildGraphQL()
     this.$exists = this.buildExists()

--- a/cli/packages/prisma-client-lib/src/codegen/generators/flow-client.ts
+++ b/cli/packages/prisma-client-lib/src/codegen/generators/flow-client.ts
@@ -4,7 +4,6 @@ import { getExistsFlowTypes } from '../../utils'
 import * as prettier from 'prettier'
 import { codeComment } from '../../utils/codeComment'
 
-import * as os from 'os'
 import { GeneratorType } from '../types';
 
 export interface RenderOptions {
@@ -75,7 +74,7 @@ type NodePromise = Promise<Node>`
 export const prisma = new Prisma()`
   }
   renderTypedefsFirstLine() {
-    return `// @flow${os.EOL}`
+    return `// @flow\r\n`
   }
   static replaceEnv(str: string): string {
     const regex = /\${env:(.*?)}/

--- a/cli/packages/prisma-client-lib/src/index.ts
+++ b/cli/packages/prisma-client-lib/src/index.ts
@@ -1,11 +1,11 @@
 export { Client } from './Client'
 export { ClientOptions, BaseClientOptions, Model } from './types'
-export { Generator } from './codegen/Generator'
-export { JavascriptGenerator } from './codegen/generators/javascript-client'
-export { TypescriptGenerator } from './codegen/generators/typescript-client'
-export {
-  TypescriptDefinitionsGenerator,
-} from './codegen/generators/typescript-definitions'
-export { GoGenerator } from './codegen/generators/go-client'
-export { FlowGenerator } from './codegen/generators/flow-client'
+// export { Generator } from './codegen/Generator'
+// export { JavascriptGenerator } from './codegen/generators/javascript-client'
+// export { TypescriptGenerator } from './codegen/generators/typescript-client'
+// export {
+//   TypescriptDefinitionsGenerator,
+// } from './codegen/generators/typescript-definitions'
+// export { GoGenerator } from './codegen/generators/go-client'
+// export { FlowGenerator } from './codegen/generators/flow-client'
 export { makePrismaClientClass } from './makePrismaClientClass'


### PR DESCRIPTION
I wanted to make datamodel.yml, define my GraphQL schema, and then use API from 'prisma' client in my react-native app,  didn't work, required node based packages, so i removed them

This is just simple overview
Can you make it work in react-native please?
I don't want server implementation, i just want to use prisma just like Parse

```import React, { Component } from 'react'
import { StyleSheet, Text, View } from 'react-native'
import { prisma } from './generated/prisma-client'

export default class App extends Component {
  async componentDidMount () {
    const users = await prisma.users()
    console.log('users', users)
  }

  render () {
    return (
      <View style={styles.container}>
        <Text>Open up App.js to start working on your app!</Text>
      </View>
    )
  }
}```