### PR TITLE
Update 03-build-rest-apis-with-prisma-JAVASCRIPT-e002.mdx

### DIFF
--- a/docs/1.32/get-started/03-build-rest-apis-with-prisma-JAVASCRIPT-e002.mdx
+++ b/docs/1.32/get-started/03-build-rest-apis-with-prisma-JAVASCRIPT-e002.mdx
@@ -45,8 +45,8 @@ Replace the current contents of `index.js` with the following code:
 
 ```js lineNumbers,copy
 const { prisma } = require('./generated/prisma-client')
-const app = express()
 const express = require('express')
+const app = express()
 const bodyParser = require('body-parser')
 
 app.use(bodyParser.json())


### PR DESCRIPTION
Fix order of express require in example. This was causing an error while following the tutorial.