### PR TITLE
Add missing space to the docs

### DIFF
--- a/docs/1.34/understand-prisma/prisma-introduction-what-why-how-j9ff.mdx
+++ b/docs/1.34/understand-prisma/prisma-introduction-what-why-how-j9ff.mdx
@@ -36,7 +36,7 @@ Prisma is the perfect tool for building GraphQL servers. The Prisma client is co
 
 ### Building REST & gRPC APIs
 
-Prisma is a great fit for building REST& gRPC APIs where it can be used in place of traditional ORMs. It provides many benefits such as type-safety, a modern API and flexible ways for reading and writing relational data.
+Prisma is a great fit for building REST & gRPC APIs where it can be used in place of traditional ORMs. It provides many benefits such as type-safety, a modern API and flexible ways for reading and writing relational data.
 
 ### CLIs, Scripts, Serverless Functions & a lot more
 


### PR DESCRIPTION
I noticed that a space was missing from `REST & gRPC` in the description. I added the space to match the same text in the title `Building REST & gRPC APIs`