### PR TITLE
Fix incorrect env var reference to PRISMA_MANAGEMENT_API_SECRET

### DIFF
--- a/docs/1.34/prisma-server/authentication-and-security-kke4.mdx
+++ b/docs/1.34/prisma-server/authentication-and-security-kke4.mdx
@@ -58,7 +58,7 @@ Unless `managementApiSecret` is defined in the Docker configuration, everyone wi
 
 </Warning>
 
-After setting `managementApiSecret`, you need to run `docker-compose up -d` to recreate the containers. After that, you'll need to use the environment variable `PRISMA_MANAGEMENT_SECRET` to authenticate with the Management API from the Prisma CLI, learn more [here](#using-the-prisma-cli).
+After setting `managementApiSecret`, you need to run `docker-compose up -d` to recreate the containers. After that, you'll need to use the environment variable `PRISMA_MANAGEMENT_API_SECRET` to authenticate with the Management API from the Prisma CLI, learn more [here](#using-the-prisma-cli).
 
 ### Management API token
 


### PR DESCRIPTION
This file at one point incorrectly refers to the needed PRISMA_MANAGEMENT_API_SECRET env var as PRISMA_MANAGEMENT_SECRET