### PR TITLE
 Name `t` replaced by more verbose `transaction` 

### DIFF
--- a/docs/1.34/understand-prisma/prisma-vs-traditional-orms/prisma-vs-sequelize-c4fk.mdx
+++ b/docs/1.34/understand-prisma/prisma-vs-traditional-orms/prisma-vs-sequelize-c4fk.mdx
@@ -353,29 +353,29 @@ const newUser = await prisma.createUser({
 <Code hideCopy={true} languages={["Manual", "Automatic"]}>
 
 ```ts
-return sequelize.transaction(async t => {
+return sequelize.transaction(async transaction => {
   const user = await User.create({
     name: "Alice",
     email: "alice@prisma,io"
   }, { 
-    transaction: t 
+    transaction
   })
   const post1 = await Post.create({
     title: "Join us for GraphQL Conf in 2019"
   }, { 
-    transaction: t 
+    transaction
   })
   const post2 = await Post.create({
     title: "Subscribe to GraphQL Weekly for GraphQL news"
   }, { 
-    transaction: t 
+    transaction
   })
   await user.setPosts([post1, post2])
 })
 ```
 
 ```ts
-return sequelize.transaction(async t => {
+return sequelize.transaction(async transaction => {
   try {
       const user = await User.create({
       name: "Alice",
@@ -389,7 +389,7 @@ return sequelize.transaction(async t => {
     })
     await user.setPosts([post1, post2])
   } catch(e) {
-    return t.rollback()
+    return transaction.rollback()
   }
 })
 ```

--- a/docs/1.34/understand-prisma/prisma-vs-traditional-orms/prisma-vs-sequelize-c4fk.mdx
+++ b/docs/1.34/understand-prisma/prisma-vs-traditional-orms/prisma-vs-sequelize-c4fk.mdx
@@ -375,7 +375,7 @@ return sequelize.transaction(async t => {
 ```
 
 ```ts
-return sequelize.transaction(async transaction => {
+return sequelize.transaction(async t => {
   try {
       const user = await User.create({
       name: "Alice",


### PR DESCRIPTION
Fix in docs 1.34