### PR TITLE
[WIP] allow comments in enum values

### DIFF
--- a/server/prisma-rs/libs/datamodel/src/ast/mod.rs
+++ b/server/prisma-rs/libs/datamodel/src/ast/mod.rs
@@ -363,6 +363,7 @@ pub struct EnumValue {
     pub name: String,
     /// The location of this enum value in the text representation.
     pub span: Span,
+    pub documentation: Option<Comment>,
 }
 
 impl WithName for EnumValue {

--- a/server/prisma-rs/libs/datamodel/src/ast/parser/datamodel.pest
+++ b/server/prisma-rs/libs/datamodel/src/ast/parser/datamodel.pest
@@ -13,6 +13,7 @@
 // Treat every whitespace the same for now.
 WHITESPACE = @{ SPACE_SEPARATOR | NEWLINE }
 // Comment ignores everything until end of line.
+// This rule is never used in the parser. It just exists to allow comments starting with // which will be ignored by the parser.
 COMMENT = @{ (!"///") ~ "//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE? }
 BLOCK_OPEN = @{ "{" }
 BLOCK_CLOSE = @{ "}" }
@@ -108,7 +109,7 @@ model_declaration = { doc_comment* ~ (MODEL_KEYWORD | TYPE_KEYWORD) ~ identifier
 // ######################################
 // Enum declarations
 // ######################################
-enum_field_declaration = @{ identifier }
+enum_field_declaration = { doc_comment* ~ identifier }
 enum_declaration = { doc_comment* ~ ENUM_KEYWORD ~ identifier ~ BLOCK_OPEN ~ (enum_field_declaration | ( "@@" ~ directive )  )* ~ BLOCK_CLOSE }
 
 // ######################################

--- a/server/prisma-rs/libs/datamodel/src/dml/enummodel.rs
+++ b/server/prisma-rs/libs/datamodel/src/dml/enummodel.rs
@@ -7,16 +7,22 @@ pub struct Enum {
     /// Name of the enum.
     pub name: String,
     /// Values of the enum.
-    pub values: Vec<String>,
+    pub values: Vec<EnumValue>,
     /// Comments for this enum.
     pub documentation: Option<String>,
     /// Database internal name of this enum.
     pub database_name: Option<String>,
 }
 
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct EnumValue {
+    pub name: String,
+    pub documentation: Option<String>,
+}
+
 impl Enum {
     /// Creates a new enum with the given name and values.
-    pub fn new(name: &str, values: Vec<String>) -> Enum {
+    pub fn new(name: &str, values: Vec<EnumValue>) -> Enum {
         Enum {
             name: String::from(name),
             values: values,

--- a/server/prisma-rs/libs/datamodel/src/dml/validator/lift.rs
+++ b/server/prisma-rs/libs/datamodel/src/dml/validator/lift.rs
@@ -91,7 +91,14 @@ impl LiftAstToDml {
     fn lift_enum(&self, ast_enum: &ast::Enum) -> Result<dml::Enum, ErrorCollection> {
         let mut en = dml::Enum::new(
             &ast_enum.name.name,
-            ast_enum.values.iter().map(|x| x.name.clone()).collect(),
+            ast_enum
+                .values
+                .iter()
+                .map(|ast_value| dml::EnumValue {
+                    name: ast_value.name.clone(),
+                    documentation: ast_value.documentation.clone().map(|x| x.text),
+                })
+                .collect(),
         );
         en.documentation = ast_enum.documentation.clone().map(|comment| comment.text);
 

--- a/server/prisma-rs/libs/datamodel/src/dml/validator/lower.rs
+++ b/server/prisma-rs/libs/datamodel/src/dml/validator/lower.rs
@@ -81,8 +81,9 @@ impl LowerDmlToAst {
                 .values
                 .iter()
                 .map(|v| ast::EnumValue {
-                    name: v.clone(),
+                    name: v.name.clone(),
                     span: ast::Span::empty(),
+                    documentation: enm.documentation.clone().map(|text| ast::Comment { text }),
                 })
                 .collect(),
             directives: self.directives.enm.serialize(enm, datamodel)?,

--- a/server/prisma-rs/libs/datamodel/src/dmmf/dmmf.rs
+++ b/server/prisma-rs/libs/datamodel/src/dmmf/dmmf.rs
@@ -52,6 +52,7 @@ pub struct Model {
     pub documentation: Option<String>,
 }
 
+// TODO: should the dmmf also have a rich structure for enum values?
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Enum {

--- a/server/prisma-rs/libs/datamodel/src/dmmf/from_dmmf.rs
+++ b/server/prisma-rs/libs/datamodel/src/dmmf/from_dmmf.rs
@@ -2,7 +2,7 @@ use super::dmmf::*;
 use crate::ast::Span;
 use crate::common::FromStrAndSpan;
 use crate::common::PrismaType;
-use crate::dml;
+use crate::{dml, EnumValue};
 use chrono::{DateTime, Utc};
 
 fn type_from_string(scalar: &str) -> PrismaType {
@@ -89,7 +89,14 @@ pub fn get_field_arity(is_required: bool, is_list: bool) -> dml::FieldArity {
 pub fn enum_from_dmmf(en: &Enum) -> dml::Enum {
     dml::Enum {
         name: en.name.clone(),
-        values: en.values.clone(),
+        values: en
+            .values
+            .iter()
+            .map(|x| EnumValue {
+                name: x.to_string(),
+                documentation: None,
+            })
+            .collect(),
         database_name: en.db_name.clone(),
         documentation: en.documentation.clone(),
     }

--- a/server/prisma-rs/libs/datamodel/src/dmmf/to_dmmf.rs
+++ b/server/prisma-rs/libs/datamodel/src/dmmf/to_dmmf.rs
@@ -31,7 +31,7 @@ fn get_field_type(field: &dml::Field) -> String {
 pub fn enum_to_dmmf(en: &dml::Enum) -> Enum {
     Enum {
         name: en.name.clone(),
-        values: en.values.clone(),
+        values: en.values.iter().map(|v| v.name.to_string()).collect(),
         db_name: en.database_name.clone(),
         documentation: en.documentation.clone(),
     }

--- a/server/prisma-rs/libs/datamodel/tests/base/basic.rs
+++ b/server/prisma-rs/libs/datamodel/tests/base/basic.rs
@@ -32,6 +32,7 @@ fn parse_basic_enum() {
         ADMIN
         ADMIN_USER
         Admin_User
+        /// This is a comment
         HHorse99
     }
     "#;
@@ -44,7 +45,9 @@ fn parse_basic_enum() {
     role_enum.assert_has_value("Admin");
     role_enum.assert_has_value("ADMIN_USER");
     role_enum.assert_has_value("Admin_User");
-    role_enum.assert_has_value("HHorse99");
+    role_enum
+        .assert_has_value("HHorse99")
+        .assert_has_comment("This is a comment");
 }
 
 #[test]

--- a/server/prisma-rs/libs/datamodel/tests/common.rs
+++ b/server/prisma-rs/libs/datamodel/tests/common.rs
@@ -29,7 +29,11 @@ pub trait ModelAsserts {
 }
 
 pub trait EnumAsserts {
-    fn assert_has_value(&self, t: &str) -> &Self;
+    fn assert_has_value(&self, t: &str) -> &dml::EnumValue;
+}
+
+pub trait EnumValueAsserts {
+    fn assert_has_comment(&self, c: &str) -> &Self;
 }
 
 pub trait DatamodelAsserts {
@@ -206,14 +210,19 @@ impl ModelAsserts for dml::Model {
 }
 
 impl EnumAsserts for dml::Enum {
-    fn assert_has_value(&self, t: &str) -> &Self {
+    fn assert_has_value(&self, t: &str) -> &dml::EnumValue {
         let pred = String::from(t);
         self.values
             .iter()
-            .find(|x| **x == pred)
-            .expect(format!("Field {} not found", t).as_str());
+            .find(|x| x.name == pred)
+            .expect(format!("Value {} not found", t).as_str())
+    }
+}
 
-        return self;
+impl EnumValueAsserts for dml::EnumValue {
+    fn assert_has_comment(&self, c: &str) -> &Self {
+        assert_eq!(self.documentation, Some(c.to_string()));
+        self
     }
 }
 

--- a/server/prisma-rs/migration-engine/connectors/migration-connector/src/steps.rs
+++ b/server/prisma-rs/migration-engine/connectors/migration-connector/src/steps.rs
@@ -172,7 +172,7 @@ pub struct DeleteField {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateEnum {
     pub name: String,
-    pub values: Vec<String>,
+    pub values: Vec<EnumValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub db_name: Option<String>,
 }
@@ -195,7 +195,7 @@ pub struct UpdateEnum {
     pub new_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub values: Option<Vec<String>>,
+    pub values: Option<Vec<EnumValue>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none", deserialize_with = "some_option")]
     pub db_name: Option<Option<String>>,

--- a/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_schema_calculator.rs
+++ b/server/prisma-rs/migration-engine/connectors/sql-migration-connector/src/database_schema_calculator.rs
@@ -238,7 +238,7 @@ impl FieldExtensions for Field {
                     .values
                     .first()
                     .expect(&format!("Enum {} did not contain any values.", enum_name));
-                Value::String(first_value.to_string())
+                Value::String(first_value.name.to_string())
             }
             _ => unimplemented!("this functions must only be called for scalar fields"),
         })

--- a/server/prisma-rs/migration-engine/core/tests/datamodel_steps_inferrer_tests.rs
+++ b/server/prisma-rs/migration-engine/core/tests/datamodel_steps_inferrer_tests.rs
@@ -273,7 +273,16 @@ fn infer_CreateEnum() {
     let expected = vec![MigrationStep::CreateEnum(CreateEnum {
         name: "Test".to_string(),
         db_name: None,
-        values: vec!["A".to_string(), "B".to_string()],
+        values: vec![
+            EnumValue {
+                name: "A".to_string(),
+                documentation: None,
+            },
+            EnumValue {
+                name: "B".to_string(),
+                documentation: None,
+            },
+        ],
     })];
     assert_eq!(steps, expected);
 }

--- a/server/prisma-rs/migration-engine/core/tests/migration_persistence_tests.rs
+++ b/server/prisma-rs/migration-engine/core/tests/migration_persistence_tests.rs
@@ -8,7 +8,7 @@ use test_harness::*;
 
 #[test]
 fn last_should_return_none_if_there_is_no_migration() {
-    test_each_connector(|_,engine| {
+    test_each_connector(|_, engine| {
         let persistence = engine.connector().migration_persistence();
         let result = persistence.last();
         assert_eq!(result.is_some(), false);
@@ -17,7 +17,7 @@ fn last_should_return_none_if_there_is_no_migration() {
 
 #[test]
 fn last_must_return_none_if_there_is_no_successful_migration() {
-    test_each_connector(|_,engine| {
+    test_each_connector(|_, engine| {
         let persistence = engine.connector().migration_persistence();
         persistence.create(Migration::new("my_migration".to_string()));
         let loaded = persistence.last();
@@ -27,7 +27,7 @@ fn last_must_return_none_if_there_is_no_successful_migration() {
 
 #[test]
 fn load_all_should_return_empty_if_there_is_no_migration() {
-    test_each_connector(|_,engine| {
+    test_each_connector(|_, engine| {
         let persistence = engine.connector().migration_persistence();
         let result = persistence.load_all();
         assert_eq!(result.is_empty(), true);
@@ -36,14 +36,15 @@ fn load_all_should_return_empty_if_there_is_no_migration() {
 
 #[test]
 fn load_all_must_return_all_created_migrations() {
-    test_each_connector(|sql_family,engine| {
+    test_each_connector(|sql_family, engine| {
         let persistence = engine.connector().migration_persistence();
         let migration1 = persistence.create(Migration::new("migration_1".to_string()));
         let migration2 = persistence.create(Migration::new("migration_2".to_string()));
         let migration3 = persistence.create(Migration::new("migration_3".to_string()));
 
         let mut result = persistence.load_all();
-        if sql_family == SqlFamily::Mysql { // TODO: mysql currently looses milli seconds on loading
+        if sql_family == SqlFamily::Mysql {
+            // TODO: mysql currently looses milli seconds on loading
             result[0].started_at = migration1.started_at;
             result[1].started_at = migration2.started_at;
             result[2].started_at = migration3.started_at;
@@ -54,7 +55,7 @@ fn load_all_must_return_all_created_migrations() {
 
 #[test]
 fn create_should_allow_to_create_a_new_migration() {
-    test_each_connector(|sql_family,engine| {
+    test_each_connector(|sql_family, engine| {
         let datamodel = datamodel::parse(
             r#"
             model Test {
@@ -69,7 +70,16 @@ fn create_should_allow_to_create_a_new_migration() {
         migration.datamodel = datamodel;
         migration.datamodel_steps = vec![MigrationStep::CreateEnum(CreateEnum {
             name: "MyEnum".to_string(),
-            values: vec!["A".to_string(), "B".to_string()],
+            values: vec![
+                datamodel::dml::EnumValue {
+                    name: "A".to_string(),
+                    documentation: None,
+                },
+                datamodel::dml::EnumValue {
+                    name: "B".to_string(),
+                    documentation: None,
+                },
+            ],
             db_name: None,
         })];
         migration.errors = vec!["error1".to_string(), "error2".to_string()];
@@ -79,7 +89,8 @@ fn create_should_allow_to_create_a_new_migration() {
 
         assert_eq!(result, migration);
         let mut loaded = persistence.last().unwrap();
-        if sql_family == SqlFamily::Mysql { // TODO: mysql currently looses milli seconds on loading
+        if sql_family == SqlFamily::Mysql {
+            // TODO: mysql currently looses milli seconds on loading
             loaded.started_at = migration.started_at;
         }
         assert_eq!(loaded, migration);
@@ -88,7 +99,7 @@ fn create_should_allow_to_create_a_new_migration() {
 
 #[test]
 fn create_should_increment_revisions() {
-    test_each_connector(|_,engine| {
+    test_each_connector(|_, engine| {
         let persistence = engine.connector().migration_persistence();
         let migration1 = persistence.create(Migration::new("migration_1".to_string()));
         let migration2 = persistence.create(Migration::new("migration_2".to_string()));
@@ -98,7 +109,7 @@ fn create_should_increment_revisions() {
 
 #[test]
 fn update_must_work() {
-    test_each_connector(|sql_family,engine| {
+    test_each_connector(|sql_family, engine| {
         let persistence = engine.connector().migration_persistence();
         let migration = persistence.create(Migration::new("my_migration".to_string()));
 
@@ -117,7 +128,8 @@ fn update_must_work() {
         assert_eq!(loaded.applied, params.applied);
         assert_eq!(loaded.rolled_back, params.rolled_back);
         assert_eq!(loaded.errors, params.errors);
-        if sql_family != SqlFamily::Mysql { // TODO: mysql currently looses milli seconds on loading
+        if sql_family != SqlFamily::Mysql {
+            // TODO: mysql currently looses milli seconds on loading
             assert_eq!(loaded.finished_at, params.finished_at);
         }
         assert_eq!(loaded.name, params.new_name);

--- a/server/prisma-rs/prisma-models/src/datamodel_converter.rs
+++ b/server/prisma-rs/prisma-models/src/datamodel_converter.rs
@@ -39,7 +39,7 @@ impl<'a> DatamodelConverter<'a> {
             .enums()
             .map(|e| InternalEnum {
                 name: e.name.clone(),
-                values: e.values.clone(),
+                values: e.values.iter().map(|v| v.name.clone()).collect(),
             })
             .collect()
     }
@@ -418,7 +418,7 @@ impl DatamodelFieldExtensions for dml::Field {
                     .find(|e| e.name == name.clone())
                     .map(|e| InternalEnum {
                         name: e.name.clone(),
-                        values: e.values.clone(),
+                        values: e.values.iter().map(|v| v.name.clone()).collect(),
                     })
             }
             _ => None,


### PR DESCRIPTION
**Warning** - This PR contains potentially breaking changes. Those things have to be validated before merging:
- The file `steps.rs` changed in a backwards incompatible way. The field `values` on `Enum` changed from a plain `String` to the struct `EnumValue`. This has the effect that steps for enums stored in the db or file system of the user cannot be parsed anymore. 
