### PR TITLE
Pull command returns error

### DIFF
--- a/docs/1.34/prisma-server/deployment-environments/docker-rty1.mdx
+++ b/docs/1.34/prisma-server/deployment-environments/docker-rty1.mdx
@@ -14,7 +14,7 @@ Prisma servers can be run with [Docker](https://www.docker.com/). This page cont
 The `prisma` Docker image is [available via Docker Hub](https://hub.docker.com/r/prismagraphql/prisma/). You can pull the latest released version of the image using the following command:
 
 ```bash
-docker pull prismagraphql/prisma
+docker pull prismagraphql/prisma:1.34-heroku
 ```
 
 ## Common workflows


### PR DESCRIPTION
The command, ``docker pull prismagraphql/prisma`` assumes a **latest** version tag of the image. As of now, no such tag [exists](https://hub.docker.com/r/prismagraphql/prisma/tags). The newest tag is **1.34-heroku**.