### PR TITLE
Extend Docker build to allow for a folder called prerun_hook_files

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -30,6 +30,7 @@ lazy val commonSettings = Seq(
 
 lazy val commonServerSettings = commonSettings ++ Seq(libraryDependencies ++= commonServerDependencies)
 lazy val prerunHookFile = new java.io.File(sys.props("user.dir") + "/prerun_hook.sh")
+lazy val prerunHookFiles = new java.io.File(sys.props("user.dir") + "/prerun_hook_files")
 
 def commonDockerImageSettings(imageName: String, baseImage: String, tag: String) = commonServerSettings ++ Seq(
   imageNames in docker := Seq(
@@ -43,6 +44,9 @@ def commonDockerImageSettings(imageName: String, baseImage: String, tag: String)
     new Dockerfile {
       from(s"$baseImage:$tag")
       copy(appDir, targetDir)
+      if (prerunHookFiles.exists) {
+        copy(prerunHookFiles, s"$targetDir/prerun_hook_files")
+      }
       copy(prerunHookFile , s"$targetDir/prerun_hook.sh")
       runShell(s"touch", s"$targetDir/start.sh")
       runShell("echo", "'#!/bin/bash'", ">>", s"$targetDir/start.sh")


### PR DESCRIPTION
If the folder exists in cwd, will be copied alongside the prerun_hook.sh script. Files inside will then be available to the script (from /app/prerun_hook_files).

References issue #4417

By putting certificates in this folder, I can use the Java keytool to add them to the store in the prerun_hook.sh script. These certificates are then successfully used when connecting to a Mongo database using ssl.