### PR TITLE
Name of environment variable is wrong

### DIFF
--- a/docs/1.34/prisma-server/authentication-and-security-kke4.mdx
+++ b/docs/1.34/prisma-server/authentication-and-security-kke4.mdx
@@ -58,7 +58,7 @@ Unless `managementApiSecret` is defined in the Docker configuration, everyone wi
 
 </Warning>
 
-After setting `managementApiSecret`, you need to run `docker-compose up -d` to recreate the containers. After that, you'll need to use the environment variable `PRISMA_MANAGEMENT_SECRET` to authenticate with the Management API from the Prisma CLI, learn more [here](#using-the-prisma-cli).
+After setting `managementApiSecret`, you need to run `docker-compose up -d` to recreate the containers. After that, you'll need to use the environment variable `PRISMA_MANAGEMENT_API_SECRET` to authenticate with the Management API from the Prisma CLI, learn more [here](#using-the-prisma-cli).
 
 ### Management API token
 


### PR DESCRIPTION
**Describe the bug**
The environment variable is wrong, using the described name doesn't work and the cli will spit out an unauthorised error. 

**To Reproduce**
In your .env file declare PRISMA_MANAGEMENT_SECRET and use it in your docker.compose file.
After you build and run docker try running `prisma deploy` the result should be that you aren't authorised.

**Expected behavior**
The declared .env variable should be picked up by the prisma cli and you should be able to deploy as per usual.

**Versions (please complete the following information):**
 - Connector:`Postgres:12`
 - Prisma Server: 1.34.10
 - Prisma CLI version: prisma/1.34.10 (windows-x64) node-v13.6.0
 - OS:`Windows 10` 

**Additional context**
The described environment variable didn't work and after some research I found the correct name of the variable the cli is going to be looking for as mentioned on your page but over here https://www.prisma.io/docs/faq/service-secret-vs-management-api-secret-fq01/