### PR TITLE
delete `post-deploy` hook info

### DIFF
--- a/docs/1.34/get-started/02-change-data-model-JAVASCRIPT-c001.mdx
+++ b/docs/1.34/get-started/02-change-data-model-JAVASCRIPT-c001.mdx
@@ -72,17 +72,6 @@ prisma generate
 
 The Prisma client library in the `/generated/prisma-client` directory is now being updated and its API has been adjusted to use the new datamodel.
 
-<Info>
-
-You can ensure that your Prisma client is automatically being updated after every deploy by adding the following lines to your `prisma.yml`:
-
-```yml copy
-hooks:
-  post-deploy:
-    - prisma generate
-```
-
-</Info>
 
 ## Read and write nested objects
 


### PR DESCRIPTION
Since Prisma 1.31, the Prisma client is generated automatically after running `prisma deploy`. It is not necessary to generate it via a `post-deploy` hook any more