### PR TITLE
Remove `-p` short option for `prisma export --project`

### DIFF
--- a/cli/packages/prisma-cli-core/src/commands/export/index.ts
+++ b/cli/packages/prisma-cli-core/src/commands/export/index.ts
@@ -19,7 +19,6 @@ export default class Export extends Command {
     }),
     ['project']: flags.string({
       description: 'Path to Prisma definition file',
-      char: 'p',
     }),
   }
   async run() {


### PR DESCRIPTION
As you can see in the output of `prisma export --help`, the short option `-p` is used **twice** for two different options (`--path` and `--project`).
![image](https://user-images.githubusercontent.com/325095/102503469-0d6a6480-4080-11eb-8260-a0d4d612d813.png)

This doesn't work obviously so this PR just removes the short option `-p` for `--project` (which is being ignored anyway).
This change should have 0 impact on the behaviour of the command. It will only affect the output of `--help`.